### PR TITLE
Fix to deckmon gears inverted colors by khonkhortisan

### DIFF
--- a/src/pokemanki/main.py
+++ b/src/pokemanki/main.py
@@ -139,6 +139,10 @@ def replace_gears(deck_browser, content):
         name = next((pokemon[0] for pokemon in pokemons if pokemon[1] == deck_id), None)
         if name:
             tr.select("img.gears")[0]["src"] = "pokemon_images/" + name + ".png"
+            tr.select("img.gears")[0]["class"] = "gears pokemon"
+    style = soup.new_tag("style")
+    style.string = ".gears.pokemon{filter:none;opacity:1}"
+    soup.append(style)
     content.tree = soup
 
 


### PR DESCRIPTION
#### Description
Applies khonkhortisan's fix to invered deckmon gears colors. #8

#### Checklist
- [X] I've read the [contribution guideline](./docs/contributing.md)
- [X] I've tested my change with the following Anki version: 2.1.54
- [X] I've tested my change on the following operating system(s): Linux and Windows
- [X] If the change is related to an issue, a commit message of the above description references the issue
  - [X] If the change resolves an issue, a commit message or the above description links the issue with a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)