### PR TITLE
Allow trading of level 100 Pokémon.

### DIFF
--- a/src/pokemanki/trades.py
+++ b/src/pokemanki/trades.py
@@ -105,7 +105,7 @@ class Trades:
             possiblehaves = []
             for item in self.allpokemon:
                 if item[1] in graderanges[want[1]] and (
-                    item[2] < int(pokemon[2]) < item[3]
+                    item[2] < int(pokemon[2]) <= item[3]
                 ):
                     possiblehaves.append(item)
 


### PR DESCRIPTION
#### Description

This allows for Pokémon that have reached level 100 to appear as options for trading. As it is, the max cap is level 99, and as soon as they hit level 100, your Pokémon are removed from the pool, which can lead to lots of days with no trades available once most of your Pokémon have reached that level cap. This solves issue [#50](https://github.com/sivenchinniah/Pokemanki/issues/50) from the main repo, and resolves #19 here.

#### Checklist
- [X] I've read the [contribution guideline](./docs/contributing.md)
- [X] I've tested my change with the following Anki version: 2.1.54
- [X] I've tested my change on the following operating system(s): Windows and Manjaro.
- [X] If the change is related to an issue, a commit message of the above description references the issue
  - [X] If the change resolves an issue, a commit message or the above description links the issue with a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
