### PR TITLE
fix encoding error due to non-ascii character

### DIFF
--- a/src/pokemanki/web.js
+++ b/src/pokemanki/web.js
@@ -1,4 +1,4 @@
-/* Pokémanki
+/* Pokemanki
  * Copyright (C) 2022 Exkywor and zjosua
  * 
  * This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
#### Description
my partner used the original pokemanki addon but upgraded to the latest anki version today & found than pokemanki no longer worked. i directed her to this fork and she installed it, but was hit by an error when loading the stats page. i didn't keep a copy of the stack trace, but it was an encoding error when reading `web.js` saying that a character was out of range. turns out the issue was this accent character in the copyright text - i changed it to a regular `e` and it worked after that.

btw thank you for maintaining this addon for newer Anki versions :)

#### Checklist
- [x] I've read the [contribution guideline](./docs/contributing.md)
- [x] I've tested my change with the following Anki version: 2.1.54
- [x] I've tested my change on the following operating system(s): macOS Mojave (10.14.6)
