### PR TITLE
Fix add-on breaking pycmd messages with return values

### DIFF
--- a/src/pokemanki/main.py
+++ b/src/pokemanki/main.py
@@ -128,9 +128,9 @@ def message_handler(
 ) -> Tuple[bool, Any]:
     # https://github.com/ankitects/anki/blob/main/qt/tools/genhooks_gui.py#L618
     if not type(context) == aqt.stats.NewDeckStats:
-        return (False, None)
+        return handled
     if not message.startswith("Pokemanki#"):
-        return (False, None)
+        return handled
     f = get_synced_conf()["decks_or_tags"]
     if message == "Pokemanki#currentDeck":
         html = pokemon_display(f, False).replace("`", "'")


### PR DESCRIPTION
#### Description

Pokemanki has a critical bug that's breaking all add-ons which rely on getting a return value from `pycmd()`. The add-on is returning `(False, None)` in the `webview_did_receive_js_message` hook for messages it's not concerned with. This removes return values for other add-ons. The add-on should instead return `handled` [unchanged](https://github.com/ankitects/anki/blob/c112236dd96e49222e2e9cb0871e1330a1671248/qt/tools/genhooks_gui.py#L667) to preserve return values. The AudioVisual Feedback add-on relies on return values and is affected by this bug: https://github.com/AnKing-VIP/ankiweb-placeholder/issues/64

#### Checklist
- [x] I've read the [contribution guideline](./docs/contributing.md)
- [x] I've tested my change with the following Anki version:
  - [x] 2.1.65 
- [x] I've tested my change on the following operating system(s):
  - [x] Windows
- [x] If the change is related to an issue, a commit message or the above description references the issue
  - [x] If the change resolves an issue, a commit message or the above description links the issue with a [keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
